### PR TITLE
Removed docker compose file network config.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -53,8 +53,3 @@ services:
     ports:
       - "1025:1025"
       - "8025:8025"
-
-networks:
-  default:
-    external:
-      name: pulpocon


### PR DESCRIPTION
There is no need to have an external network if we are not going to connect to it from other docker containers outside the docker compose file.
 Also it was a compatibility problem with docker compose plugin V2